### PR TITLE
feat: Eraser on stylus button press and release.   

### DIFF
--- a/lib/data/prefs.dart
+++ b/lib/data/prefs.dart
@@ -100,6 +100,7 @@ abstract class Prefs {
   static late final PlainPref<bool> autoClearWhiteboardOnExit;
 
   static late final PlainPref<bool> disableEraserAfterUse;
+  static late final PlainPref<bool> eraserOnStylusButtonPressAndRelease;
   static late final PlainPref<bool> hideFingerDrawingToggle;
 
   static late final PlainPref<List<String>> recentColorsChronological;
@@ -209,6 +210,7 @@ abstract class Prefs {
     autoClearWhiteboardOnExit = PlainPref('autoClearWhiteboardOnExit', false);
 
     disableEraserAfterUse = PlainPref('disableEraserAfterUse', false);
+    eraserOnStylusButtonPressAndRelease = PlainPref('eraserOnStylusButtonPressAndRelease', false);
     hideFingerDrawingToggle = PlainPref('hideFingerDrawingToggle', false);
 
     recentColorsChronological = PlainPref('recentColorsChronological', []);

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -377,6 +377,7 @@ class TranslationsSettingsPrefLabelsEn {
 	String get maxImageSize => 'Maximum image size';
 	String get autoClearWhiteboardOnExit => 'Auto-clear the whiteboard';
 	String get disableEraserAfterUse => 'Auto-disable the eraser';
+	String get eraserOnStylusButtonPressAndRelease => 'Eraser on stylus button press and release';
 	String get hideFingerDrawingToggle => 'Hide the finger drawing toggle';
 	String get editorPromptRename => 'Prompt you to rename new notes';
 	String get hideHomeBackgrounds => 'Hide backgrounds on the home screen';
@@ -403,6 +404,7 @@ class TranslationsSettingsPrefDescriptionsEn {
 	String get preferGreyscale => 'For e-ink displays';
 	String get autoClearWhiteboardOnExit => 'Clears the whiteboard after you exit the app';
 	String get disableEraserAfterUse => 'Automatically switches back to the pen after using the eraser';
+	String get eraserOnStylusButtonPressAndRelease => 'Switch to eraser pressing stylus button and releasing it';
 	String get maxImageSize => 'Larger images will be compressed';
 	late final TranslationsSettingsPrefDescriptionsHideFingerDrawingEn hideFingerDrawing = TranslationsSettingsPrefDescriptionsHideFingerDrawingEn.internal(_root);
 	String get editorPromptRename => 'You can always rename notes later';

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -891,20 +891,49 @@ class EditorState extends State<Editor> {
     // whether the stylus button is or was pressed
     stylusButtonPressed = stylusButtonPressed || buttonPressed;
 
-    if (isHovering) {
-      if (buttonPressed) {
-        if (currentTool is Eraser) return;
-        tmpTool = currentTool;
-        currentTool = Eraser();
-        setState(() {});
-      } else {
-        if (tmpTool != null) {
-          currentTool = tmpTool!;
-          tmpTool = null;
+    if (!Prefs.eraserOnStylusButtonPressAndRelease.value) {
+      // standard behavior of stylus button, while holding is erasing
+      if (isHovering) {
+        if (buttonPressed) {
+          if (currentTool is Eraser) return;
+          tmpTool = currentTool;
+          currentTool = Eraser();
           setState(() {});
+        } else {
+          if (tmpTool != null) {
+            currentTool = tmpTool!;
+            tmpTool = null;
+            setState(() {});
+          }
         }
       }
     }
+    else {
+      // some pens do not send moving events when stylus button is pressed
+      // so switch to eraser when button is pressed and back on next press
+      if (isHovering) {
+        if (buttonPressed) {
+          // switch to Eraser
+          if (currentTool is Eraser) {
+            if (tmpTool != null) {
+              // change back original tool
+              currentTool = tmpTool!;
+              tmpTool = null;
+              setState(() {});
+            }
+            else {
+              return; // when I am on eraser and previous tool is not set, it means that Eraser is main tool
+            }
+          }
+          else {
+            tmpTool = currentTool;
+            currentTool = Eraser();
+            setState(() {});
+          }
+        }
+      }
+    }
+
   }
 
   void onMoveImage(EditorImage image, Rect offset) {

--- a/lib/pages/home/settings.dart
+++ b/lib/pages/home/settings.dart
@@ -360,6 +360,12 @@ class _SettingsPageState extends State<SettingsPage> {
                 pref: Prefs.disableEraserAfterUse,
               ),
               SettingsSwitch(
+                title: t.settings.prefLabels.eraserOnStylusButtonPressAndRelease,
+                subtitle: t.settings.prefDescriptions.eraserOnStylusButtonPressAndRelease,
+                icon: FontAwesomeIcons.eraser,
+                pref: Prefs.eraserOnStylusButtonPressAndRelease,
+              ),
+              SettingsSwitch(
                 title: t.settings.prefLabels.hideFingerDrawingToggle,
                 subtitle: () {
                   if (!Prefs.hideFingerDrawingToggle.value) {
@@ -626,3 +632,4 @@ class _SettingsPageState extends State<SettingsPage> {
     super.dispose();
   }
 }
+


### PR DESCRIPTION
Some styluses do not send move events when button is pressed. So Eraser do not work. 

This change allows switch to eraser by pressing and releasing stylus button (no more holding button), then erasing items work.

Creates new preference, which can change default behavior of pressing button when pen is above screen.

Solves issue #1410